### PR TITLE
Allow http.Message to track the tcp.Direction that it comes from

### DIFF
--- a/http/message.py
+++ b/http/message.py
@@ -10,6 +10,7 @@ class Message:
     * ts_start: when Message started arriving (dpkt timestamp)
     * ts_end: when Message had fully arrived (dpkt timestamp)
     * body_raw: body before compression is taken into account
+    * tcpdir: The tcp.Direction corresponding to the HTTP message
     '''
     def __init__(self, tcpdir, pointer, msgclass):
         '''
@@ -18,6 +19,7 @@ class Message:
         pointer = position within tcpdir.data to start parsing from. byte index
         msgclass = dpkt.http.Request/Response
         '''
+        self.tcpdir = tcpdir
         # attempt to parse as http. let exception fall out to caller
         self.msg = msgclass(tcpdir.data[pointer:])
         self.data = self.msg.data


### PR DESCRIPTION
This change allows us to do a deeper analysis of an HTTP conversation by going back to the original TCP packet stream, e.g., to detect retransmissions and packet loss.
